### PR TITLE
add requirements.txt to support python dependencies management. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Pillow==9.5.0
+#pygame
+#mutagen


### PR DESCRIPTION
Allows simpler and standard python dependencies management with

`pip install -r requirements.txt` 

Workaround for issue https://github.com/djokeur/merlinator/issues/4